### PR TITLE
Batch testing

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -45,6 +45,10 @@ def predict(args):
     output_lines = ['%f %s' % t for t in zip(predict, lines)]
     if args.max_score:
         output_lines = maxLigandScore(output_lines)
+    if args.affinity:
+        output_lines.append("# RMSD %.5f\n" % rmsd)
+    else:
+        output_lines.append("# AUC %.5f\n" % auc)
     if not args.keep:
         os.remove(test_model)
     return output_lines
@@ -115,29 +119,4 @@ if __name__ == '__main__':
         if args.max_score:
             predictions = maxLigandScore(predictions)
     out.writelines(predictions)
-    if args.affinity:
-        y_predaff = []
-        y_true = []
-        y_affinity = []
-        for line in predictions:
-            data = line.split(' ')
-            y_predaff.append(float(data[0]))
-            y_true.append(float(data[1]))
-            y_affinity.append(float(data[2]))
-        if len(np.unique(y_true)) > 1:
-            y_predaff = np.array(y_predaff)
-            y_affinity = np.array(y_affinity)
-            yt = np.array(y_true, np.bool)
-            rmsd = sklearn.metrics.mean_squared_error(y_affinity[yt], y_predaff[yt])
-            out.write("# RMSD %.5f\n" % rmsd)
-    else:
-        y_score = []
-        y_true = []
-        for line in predictions:
-            data = line.split(' ')
-            y_score.append(float(data[0]))
-            y_true.append(float(data[1]))
-        if len(np.unique(y_true)) > 1:
-            auc = sklearn.metrics.roc_auc_score(y_true, y_score)
-            out.write("# AUC %.5f\n" % auc)
 

--- a/train.py
+++ b/train.py
@@ -91,8 +91,9 @@ def evaluate_test_net(test_net, n_tests, n_rotations, offset):
     '''Evaluate a test network and return the results. The number of
     examples in the file the test_net reads from must equal n_tests,
     otherwise output will be misaligned. Can optionally take the average
-    of multiple rotations of each example. Batch size should be 1 and
-    other parameters should be set so that data access is sequential.'''
+    of multiple rotations of each example. Offset is the index into
+    the test file that will be the first example in the next batch.
+    Net parameters should be set so that data access is sequential.'''
 
     #evaluate each example with each rotation
     y_true     = [-1 for _ in xrange(n_tests)]

--- a/train.py
+++ b/train.py
@@ -11,6 +11,7 @@ import caffe
 from caffe.proto.caffe_pb2 import NetParameter, SolverParameter
 import google.protobuf.text_format as prototxt
 import time
+import psutil
 from combine_fold_results import write_results_file, combine_fold_results
 
 '''Script for training a neural net model from gnina grid data.
@@ -401,7 +402,11 @@ def train_and_test_model(args, files, outname):
         i_time_avg = (i*i_time_avg + i_time)/(i+1)
         i_left = iterations/test_interval - (i+1)
         time_left = i_time_avg * i_left
-        print "Loop time: %f (%.2fh left)" % (i_time, time_left/3600.)
+        time_str = time.strftime('%H:%M:%S', time.gmtime(time_left))
+        print "Loop time: %f (%s left)" % (i_time, time_str)
+
+        mem = psutil.Process(os.getpid()).memory_info().rss
+        print "Memory usage: %.3fgb (%d)" % (mem/1073741824., mem)
 
     if training:
         out.close()

--- a/train.py
+++ b/train.py
@@ -361,7 +361,6 @@ def train_and_test_model(args, files, outname):
         if i > 0 and not (args.reduced and last_test): #check alignment
             assert np.all(y_true == train_vals['y_true'])
             assert np.all(y_aff == train_vals['y_aff'])
-            print '\n'.join('%d %d' % t for t in zip(train_vals['y_aff'], y_aff))
 
         train_vals['y_true'] = y_true
         train_vals['y_aff'] = y_aff


### PR DESCRIPTION
- support test net batch size > 1 by keeping track of offset into test file to align consecutive tests
- use evaluate_test_net() in predict.py
- don't unnecessarily test twice per interval when training --allfolds model
- use --affinity flag in predict.py to predict affinity instead of active/decoy label
