### PR TITLE
fixed files for pickle to be binary files

### DIFF
--- a/train.py
+++ b/train.py
@@ -447,7 +447,7 @@ def train_and_test_model(args, files, outname, cont=0):
         checkname = '%s.CHECKPOINT'%outname
         if os.path.exists(checkname):
             print(checkname)
-            checkdata = pickle.load(open(checkname,'wb'))
+            checkdata = pickle.load(open(checkname,'rb'))
             (dontremove, training, prevsnap,train,test,bests,best_train_interval,prevlr, step_reduce_cnt) = checkdata
             
             if not training:
@@ -685,7 +685,7 @@ def train_and_test_model(args, files, outname, cont=0):
             checkname = '%s.CHECKPOINT'%outname
             #read previous snap
             if os.path.exists(checkname):
-              (dontremove,_,prevsnap) = pickle.load(open(checkname,'wb'))[:3]
+              (dontremove,_,prevsnap) = pickle.load(open(checkname,'rb'))[:3]
             else:
               dontremove = True
               prevsnap = None

--- a/train.py
+++ b/train.py
@@ -447,7 +447,7 @@ def train_and_test_model(args, files, outname, cont=0):
         checkname = '%s.CHECKPOINT'%outname
         if os.path.exists(checkname):
             print(checkname)
-            checkdata = pickle.load(open(checkname))
+            checkdata = pickle.load(open(checkname,'wb'))
             (dontremove, training, prevsnap,train,test,bests,best_train_interval,prevlr, step_reduce_cnt) = checkdata
             
             if not training:
@@ -685,14 +685,14 @@ def train_and_test_model(args, files, outname, cont=0):
             checkname = '%s.CHECKPOINT'%outname
             #read previous snap
             if os.path.exists(checkname):
-              (dontremove,_,prevsnap) = pickle.load(open(checkname))[:3]
+              (dontremove,_,prevsnap) = pickle.load(open(checkname,'wb'))[:3]
             else:
               dontremove = True
               prevsnap = None
 
             with DelayedInterrupt([signal.SIGTERM, signal.SIGINT]):
                 #write new snap
-                checkout = open(checkname,'w')         
+                checkout = open(checkname,'wb')         
                 pickle.dump((keepsnap, training, snapname,train,test,bests,best_train_interval,solver.get_base_lr(), step_reduce_cnt), checkout)
                 checkout.flush()
                 checkout.close()


### PR DESCRIPTION
Python 3 requires the files for pickle to be opened in binary mode, changed the files to support this. Note: this probable is a systemic issue and would need to be changed in multiple places?