### PR TITLE
Low memory combine_rows

### DIFF
--- a/combine_rows.py
+++ b/combine_rows.py
@@ -10,8 +10,7 @@ targets = dict() # name to index
 values = collections.defaultdict(dict) # indexed by row name, col name
 
 for fname in sys.argv[1:]:
-    with open(fname) as file:
-        for line in file:
+        for line in open(fname):
             (t1,t2,dist,lsim) = line.split()
             dist = float(dist)
             if t2 not in targets:

--- a/combine_rows.py
+++ b/combine_rows.py
@@ -10,13 +10,13 @@ targets = dict() # name to index
 values = collections.defaultdict(dict) # indexed by row name, col name
 
 for fname in sys.argv[1:]:
-        for line in open(fname):
-            (t1,t2,dist,lsim) = line.split()
-            dist = float(dist)
-            if t2 not in targets:
-                targets[t2] = len(target_names)
-                target_names.append(t2)
-            values[t1][t2] = (dist,lsim)
+    for line in open(fname):
+        (t1,t2,dist,lsim) = line.split()
+        dist = float(dist)
+        if t2 not in targets:
+            targets[t2] = len(target_names)
+            target_names.append(t2)
+        values[t1][t2] = (dist,lsim)
         
         
 #must have fully filled out matrix

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -9,7 +9,8 @@ from tqdm import tqdm
 
 # Parse arguments
 parser = ap.ArgumentParser()
-parser.add_argument("files", nargs="+")
+parser.add_argument("files", nargs="+", type=str)
+parser.add_argument("-out", "--output", type=str)
 args = parser.parse_args()
 
 # Open first file to get targets
@@ -68,6 +69,6 @@ rows, cols = np.where(np.isnan(lsim)) # Invalid ligand similarities
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing ligand similarity for {t1} {t2}")
 
-print("Dumping pickle object...", end="", flush=True)
-pickle.dump((dist, targets, lsim), open('matrix.pickle','wb'),-1)
+print(f"Dumping pickle object {args.out}...", end="", flush=True)
+pickle.dump((dist, targets, lsim), open(f"{args.out}", "wb"),-1)
 print("done")

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -55,10 +55,9 @@ lsim = df_lsim.values
 
 # Check properties
 print("Checking matrix properties...", flush=True)
-assert np.allclose(np.diagonal(dist), np.zeros(n_targets))
-assert np.allclose(np.diagonal(lsim), np.ones(n_targets))
-assert np.allclose(dist, dist.T)
-assert np.allclose(lsim, lsim)
+ddist, dlsim = np.diagonal(dist), np.diagonal(lsim)
+assert int(round(np.sum(ddist))) == int(round(np.sum(ddist[ddist < 0])))
+assert int(round(np.sum(dlsim[dlsim >= 0]))) - int(round(np.sum(dlsim[dlsim < 0]))) == n_targets
 print("done")
 
 # Set NaNs for compatibility with original implementation

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -73,5 +73,5 @@ for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing ligand similarity for {t1} {t2}")
 
 print(f"Dumping pickle object {args.out}...", end="", flush=True)
-pickle.dump((dist, targets, lsim), open(f"{args.out}", "wb"), -1)
+pickle.dump((dist, targets, lsim), open(f"{args.output}", "wb"), -1)
 print("done")

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -72,6 +72,6 @@ rows, cols = np.where(np.isnan(lsim))  # Invalid ligand similarities
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing ligand similarity for {t1} {t2}")
 
-print(f"Dumping pickle object {args.out}...", end="", flush=True)
+print(f"Dumping pickle object {args.output}...", end="", flush=True)
 pickle.dump((dist, targets, lsim), open(f"{args.output}", "wb"), -1)
 print("done")

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -33,27 +33,38 @@ for fname in tqdm(args.files):
     dist = np.loadtxt(fname, usecols=2)
     lsim = np.loadtxt(fname, usecols=3)
     
+    # Populate distance matrix
     if len(dist) == n_targets:
         df_dist.loc[target, ctargets] = dist
+    else:
+        print("  Invalid number of distances for {target}")
+
+    # Populate ligand similarity matrix
     if len(lsim) == n_targets:
         df_lsim.loc[target, ctargets] = lsim
+    else:
+        print("  Invalid number of ligand similarities for {target}")
 
 dist = df_dist.values
 lsim = df_lsim.values
 
+# Check properties
+print("Checking matrix properties...", flush=True)
+assert np.allclose(np.diagonal(dist), np.zeros(n_targets))
+assert np.allclose(np.diagonal(lsim), np.ones(n_targets))
+assert np.allclose(dist, dist.T)
+assert np.allclose(lsim, lsim)
+print("done")
+
+# Set NaNs for compatibility with original implementation
 dist[dist < 0] = np.nan
 lsim[lsim < 0] = np.nan
 
-
 print("Checking data...", flush=True)
-
-# Check distance
-rows, cols = np.where(np.isnan(dist))
+rows, cols = np.where(np.isnan(dist)) # Invalid distances
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing distance for {t1} {t2}")
-
-# Check ligand similarity
-rows, cols = np.where(np.isnan(lsim))
+rows, cols = np.where(np.isnan(lsim)) # Invalid ligand similarities
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing ligand similarity for {t1} {t2}")
 

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -26,7 +26,7 @@ df_dist = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_target
 df_lsim = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_targets,n_targets)))
 print("done")
 
-print("Merging data...", end="", flush=True)
+print("Merging data...", flush=True)
 for fname in tqdm(args.files):
     target = np.loadtxt(fname, usecols=0, dtype="U4")[0]
     ctargets = np.loadtxt(fname, usecols=1, dtype="U4") # Can be removed if targets == ctargets all the time
@@ -43,20 +43,19 @@ lsim = df_lsim.values
 
 dist[dist < 0] = np.nan
 lsim[lsim < 0] = np.nan
-print("done")
 
 
-print("Checking data...", end="", flush=True)
+print("Checking data...", flush=True)
 
 # Check distance
 rows, cols = np.where(np.isnan(dist))
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
-    print(f"Missing distance for {t1} {t2}")
+    print(f"  Missing distance for {t1} {t2}")
 
 # Check ligand similarity
 rows, cols = np.where(np.isnan(lsim))
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
-    print(f"Missing ligand similarity for {t1} {t2}")
+    print(f"  Missing ligand similarity for {t1} {t2}")
 
 print("Dumping pickle object...", end="", flush=True)
 pickle.dump((dist, targets, lsim), open('matrix.pickle','wb'),-1)

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse as ap
+import numpy as np
+import pandas as pd
+import pickle
+
+# Parse arguments
+parser = ap.ArgumentParser()
+parser.add_argument("files", nargs="+")
+args = parser.parse_args()
+
+# Open first file to get targets
+print("Reading targets...", end="", flush=True)
+targets = np.loadtxt(args.files[0], usecols=1, dtype="U4")
+n_targets = len(targets)
+print("done")
+
+# Build dataframe
+# Initializing the DF with a numpy array is essential for speed at assignment
+print("Allocating DataFrame memory...", end="", flush=True)
+# Protein sequence distance
+df_dist = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_targets,n_targets)))
+# Ligand similarity
+df_lsim = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_targets,n_targets)))
+print("done")
+
+print("Merging data...", end="", flush=True)
+for fname in args.files:
+    target = np.loadtxt(fname, usecols=0, dtype="U4")[0]
+    ctargets = np.loadtxt(fname, usecols=1, dtype="U4") # Can be removed if targets == ctargets all the time
+    dist = np.loadtxt(fname, usecols=2)
+    lsim = np.loadtxt(fname, usecols=3)
+    
+    if len(dist) == n_targets:
+        df_dist.loc[target, ctargets] = dist
+    if len(lsim) == n_targets:
+        df_lsim.loc[target, ctargets] = lsim
+print("done")
+
+print(df_dist.values[:10,:10])
+print(df_lsim.values[:10,:10])
+
+# Check
+print("Checking data...", end="", flush=True)
+for i in range(n_targets):
+    for j in range(n_targets):
+
+        if df_dist.values[i,j] < 0:
+            print("  Missing distance for", targets[i], targets[j])
+
+        if df_lsim.values[i,j] < 0:
+            print("  Missing ligand similarity for",targets[i],targets[j])
+
+print("done")
+
+print("Dumping pickle object...", end="", flush=True)
+pickle.dump((df_dist.values, targets, df_lsim.values), open('matrix.pickle','wb'),-1)
+print("done")

--- a/combine_rows_lowmem.py
+++ b/combine_rows_lowmem.py
@@ -23,17 +23,21 @@ print("done")
 # The DF are used to ensure that distances and ligand similarities are inserted at the correct place
 # Initializing the DF with a numpy array is essential for speed at assignment
 print("Allocating DataFrame memory...", end="", flush=True)
-df_dist = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_targets,n_targets)))
-df_lsim = pd.DataFrame(index=targets, columns=targets, data=-1*np.ones((n_targets,n_targets)))
+df_dist = pd.DataFrame(
+    index=targets, columns=targets, data=-1 * np.ones((n_targets, n_targets))
+)
+df_lsim = pd.DataFrame(
+    index=targets, columns=targets, data=-1 * np.ones((n_targets, n_targets))
+)
 print("done")
 
 print("Merging data...", flush=True)
 for fname in tqdm(args.files):
     target = np.loadtxt(fname, usecols=0, dtype="U4")[0]
-    ctargets = np.loadtxt(fname, usecols=1, dtype="U4") # Can be removed if targets == ctargets all the time
+    ctargets = np.loadtxt(fname, usecols=1, dtype="U4")
     dist = np.loadtxt(fname, usecols=2)
     lsim = np.loadtxt(fname, usecols=3)
-    
+
     # Populate distance matrix
     if len(dist) == n_targets:
         df_dist.loc[target, ctargets] = dist
@@ -62,13 +66,13 @@ dist[dist < 0] = np.nan
 lsim[lsim < 0] = np.nan
 
 print("Checking data...", flush=True)
-rows, cols = np.where(np.isnan(dist)) # Invalid distances
+rows, cols = np.where(np.isnan(dist))  # Invalid distances
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing distance for {t1} {t2}")
-rows, cols = np.where(np.isnan(lsim)) # Invalid ligand similarities
+rows, cols = np.where(np.isnan(lsim))  # Invalid ligand similarities
 for t1, t2 in zip(df_dist.index.values[rows], df_dist.columns.values[cols]):
     print(f"  Missing ligand similarity for {t1} {t2}")
 
 print(f"Dumping pickle object {args.out}...", end="", flush=True)
-pickle.dump((dist, targets, lsim), open(f"{args.out}", "wb"),-1)
+pickle.dump((dist, targets, lsim), open(f"{args.out}", "wb"), -1)
 print("done")


### PR DESCRIPTION
The script `combine_rows.py` has a high memory consumption for large datasets (such as PDBbind18) and runs out of memory on a 64GB machine.

This PR re-implements such script with a totally different approach, pre-allocating `pandas.DataFrame`s and populating them one row at a time. This approach consistently reduces the memory usage. 

The final check is also sped up using `numpy` instead of Python loops.

Since the approach is completely different from the original script, I created a new script `combine_rows_lowmem.py` instead of modifying the original one.

## Small Test

Loading only rows 1-3 and printing a 5x5 sub-matrix with the new code:
```
dist =
[[     nan      nan      nan      nan      nan]
 [0.008475 0.       0.016667 0.672362 0.628814]
 [0.025    0.016667 0.       0.664322 0.633333]
 [0.677387 0.672362 0.664322 0.       0.78191 ]
 [     nan      nan      nan      nan      nan]]

lsim=
[[     nan      nan      nan      nan      nan]
 [0.479689 1.       0.290152 0.364799 0.328125]
 [0.221582 0.290152 1.       0.300582 0.323887]
 [0.301352 0.364799 0.300582 1.       0.328125]
 [     nan      nan      nan      nan      nan]]
``` 

Loading only rows 1-3 and printing a 5x5 sub-matrix with `combine_rows.py`:
```
m =
[[     nan      nan      nan      nan      nan]
 [0.008475 0.       0.016667 0.672362 0.628814]
 [0.025    0.016667 0.       0.664322 0.633333]
 [0.677387 0.672362 0.664322 0.       0.78191 ]
 [     nan      nan      nan      nan      nan]]

lm =
[[     nan      nan      nan      nan      nan]
 [0.479689 1.       0.290152 0.364799 0.328125]
 [0.221582 0.290152 1.       0.300582 0.323887]
 [0.301352 0.364799 0.300582 1.       0.328125]
 [     nan      nan      nan      nan      nan]]
```