### PR TITLE
Added script for extending types files

### DIFF
--- a/types_extender.py
+++ b/types_extender.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+'''
+This script will generate the new types file with the lines from generate_counterexample_typeslines.py
+
+Assumptions
+	i) The data structure is <ROOT>/<POCKET>/<FILES>
+	ii) The name of the file containing the types lines to add is <ligname><SUFFIX> for each ligand in the pocket.
+	iii) the input types file has <POCKET>/<receptor file>  from which to parse the needed pockets from.
+
+INPUT
+	i) Original types file
+	ii) New types filename
+	iii) Suffix of file(s) in Pocket that contains the lines to add
+	iv) The ROOT of the data directory
+
+OUTPUT
+	i) The new types file -- note that the lines of the new types file will not necessarily be in order.
+'''
+
+import argparse, os, re, glob
+
+def check_exists(filename):
+	if os.path.isfile(filename) and os.path.getsize(filename)>0:
+		return True
+	else:
+		return False
+
+parser=argparse.ArgumentParser(description='Add lines to types file and create a new one. Assumes data file structure is ROOT/POCKET/FILES.')
+parser.add_argument('-i','--input',type=str,required=True,help='Types file you will be extending.')
+parser.add_argument('-o','--output',type=str,required=True,help='Name of the extended types file.')
+parser.add_argument('-s','--suffix',type=str,required=True,help='Suffix of the file(s) containing the lines to add for a given pocket. This is the output of generate_counterexample_typeslines.py.')
+parser.add_argument('-r','--root',default='',help='Root of the data directory. Defaults to current working directory.')
+args=parser.parse_args()
+
+completed=set()
+with open(args.output,'w') as outfile:
+	with open(args.input) as infile:
+		for line in infile:
+			outfile.write(line)
+			m=re.search(r' (\S+)/',line)
+			pocket=m.group(1)
+
+			if pocket not in completed:
+				completed.add(pocket)
+				toadd=glob.glob(os.path.join(args.root,pocket,'')+'*'+args.suffix)
+				for thing in toadd:
+					with open(thing) as linesfile:
+						for line2 in linesfile:
+							outfile.write(line2)

--- a/types_extender.py
+++ b/types_extender.py
@@ -4,13 +4,13 @@ This script will generate the new types file with the lines from generate_counte
 
 Assumptions
 	i) The data structure is <ROOT>/<POCKET>/<FILES>
-	ii) The name of the file containing the types lines to add is <ligname><SUFFIX> for each ligand in the pocket.
+	ii) The name of the file containing the types lines to add is <NAME> for each pocket in the types file.
 	iii) the input types file has <POCKET>/<receptor file>  from which to parse the needed pockets from.
 
 INPUT
 	i) Original types file
 	ii) New types filename
-	iii) Suffix of file(s) in Pocket that contains the lines to add
+	iii) Name of file in Pocket that contains the lines to add
 	iv) The ROOT of the data directory
 
 OUTPUT
@@ -28,7 +28,7 @@ def check_exists(filename):
 parser=argparse.ArgumentParser(description='Add lines to types file and create a new one. Assumes data file structure is ROOT/POCKET/FILES.')
 parser.add_argument('-i','--input',type=str,required=True,help='Types file you will be extending.')
 parser.add_argument('-o','--output',type=str,required=True,help='Name of the extended types file.')
-parser.add_argument('-s','--suffix',type=str,required=True,help='Suffix of the file(s) containing the lines to add for a given pocket. This is the output of generate_counterexample_typeslines.py.')
+parser.add_argument('-n','--name',type=str,required=True,help='Name of the file containing the lines to add for a given pocket. This is the output of generate_counterexample_typeslines.py.')
 parser.add_argument('-r','--root',default='',help='Root of the data directory. Defaults to current working directory.')
 args=parser.parse_args()
 
@@ -42,8 +42,6 @@ with open(args.output,'w') as outfile:
 
 			if pocket not in completed:
 				completed.add(pocket)
-				toadd=glob.glob(os.path.join(args.root,pocket,'')+'*'+args.suffix)
-				for thing in toadd:
-					with open(thing) as linesfile:
-						for line2 in linesfile:
-							outfile.write(line2)
+				with open(os.path.join(args.root,pocket,args.name)) as linesfile:
+					for line2 in linesfile:
+						outfile.write(line2)


### PR DESCRIPTION
Added types_extender.py script.

This script will generate a new types file, given an input types file, new filename, ROOT, and the name used in generate_counterexample_typeslines.py.

I also edited the README to reflect the addition of this new script.